### PR TITLE
updated comments for createEIP712AuthMessageSigner function

### DIFF
--- a/docs/quick_start/connect_to_the_clearnode.md
+++ b/docs/quick_start/connect_to_the_clearnode.md
@@ -319,6 +319,7 @@ ws.onmessage = async (event) => {
           },
           { 
             // Domain for EIP-712 signing
+            // Must be equal to your app_name from authRequestMsg
             name: 'Your Domain',
           },
         )
@@ -406,6 +407,7 @@ ws.onmessage = async (event) => {
           },
           { 
             // Domain for EIP-712 signing
+            // Must be equal to your app_name from authRequestMsg
             name: 'Your Domain',
           },
         )

--- a/docs/quick_start/connect_to_the_clearnode.md
+++ b/docs/quick_start/connect_to_the_clearnode.md
@@ -284,8 +284,8 @@ const authRequestMsg = await createAuthRequestMessage({
   participant: '0xYourSignerAddress',
   app_name: 'Your Domain',
   expire: Math.floor(Date.now() / 1000) + 3600, // 1 hour expiration
-  scope: 'console',
-  application: '0xYourApplicationAddress',
+  scope: 'console', // optional
+  application: '0xYourApplicationAddress', // optional
   allowances: [],
 });
 
@@ -375,8 +375,8 @@ ws.onopen = async () => {
     participant: '0xYourSignerAddress',
     app_name: 'Your Domain',
     expire: Math.floor(Date.now() / 1000) + 3600, // 1 hour expiration
-    scope: 'console',
-    application: '0xYourApplicationAddress',
+    scope: 'console', // optional
+    application: '0xYourApplicationAddress', // optional
     allowances: [],
   });
   ws.send(authRequestMsg);


### PR DESCRIPTION
## Updates
- Added a note clarifying that `domain` **must** match `authRequestMsg.app_name`.
- Updated the `createAuthRequestMessage` JSDoc comments to mark `scope` and `application` as optional parameters.

## Message to the team
Your project is fantastic—truly a potential game-changer for GameFi. I have a couple of suggestions that could make the developer experience even smoother:

1. **SDK consistency**  
   It would help to standardize on a single library for types and signing utilities. The current mix of Viem and `ethers@5.7.2` means developers sometimes have to juggle both sets of types.

2. **Session-signing guide**  
   A short external guide on generating and signing session keys/messages would be invaluable for new contributors.

Keep up the great work, and best of luck from the Sentia team!